### PR TITLE
PR test issue 22 - Hacktoberfest

### DIFF
--- a/hacktoberfest2021/submissions/submission22.md
+++ b/hacktoberfest2021/submissions/submission22.md
@@ -1,0 +1,36 @@
+# Submission
+### Links to PRs & Issues
+
+PR: https://github.com/mattermost/mattermost-server/pull/18451
+JIRA: https://mattermost.atlassian.net/browse/MM-36862
+Issue: https://github.com/mattermost/quality-assurance/issues/22
+
+### Description of Issue
+
+Summary
+
+When deleting a reply in a thread we should also delete the participant
+from the participants array. This should happen if they have no other
+replies in that thread.
+
+### Tests Ran
+
+Test 1:
+1) Reply to someones root post 
+2) Open this thread on the RHS
+3) Delete your reply (you should not have any other replies on this thread)
+Result: On the main channel view, user avatar is removed from the root post footer and reply count is updated.
+This should also apply to the avatars in the row of the Threads list.
+
+Test 2:
+1) Reply to someones root post 
+2) Reply angain to someones root post 
+3) Open this thread on the RHS
+4) Delete one reply
+Result: On the main channel view, user avatar is still there from the root post footer, reply count is updated.
+The avatars in the row of the Threads list is still there too.
+
+Test 3:
+1) Reply to someones root post 
+2) Delete the root post
+Result: Root post and threads are deleted.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
### Test description of Issue MM-36862

When deleting a reply in a thread we should also delete the participant
from the participants array. This should happen if they have no other
replies in that thread.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

PR: https://github.com/mattermost/mattermost-server/pull/18451
JIRA: https://mattermost.atlassian.net/browse/MM-36862
Issue: https://github.com/mattermost/quality-assurance/issues/22
